### PR TITLE
Fix third person left handed rendering

### DIFF
--- a/src/main/java/cn/solarmoon/spyglass_of_curios/client/curios_renderer/SpyglassRenderer.java
+++ b/src/main/java/cn/solarmoon/spyglass_of_curios/client/curios_renderer/SpyglassRenderer.java
@@ -19,6 +19,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import top.theillusivec4.curios.api.SlotContext;
 import top.theillusivec4.curios.api.client.ICurioRenderer;
+import net.minecraft.world.entity.HumanoidArm;
 
 
 public class SpyglassRenderer implements ICurioRenderer {
@@ -54,7 +55,12 @@ public class SpyglassRenderer implements ICurioRenderer {
             matrixStack.mulPose(Axis.YP.rotationDegrees(HeadYaw));
             matrixStack.mulPose(Axis.XP.rotationDegrees(Math.max(headPitch, -30)));
             matrixStack.mulPose(Axis.ZP.rotationDegrees(180.0F));
-            matrixStack.translate(-0.1, 0.21, -0.6);
+            matrixStack.translate(0, 0.21, -0.6);
+            if (living.getMainArm() == HumanoidArm.RIGHT) {
+                matrixStack.translate(-0.1, 0, 0);
+            } else {
+                matrixStack.translate(0.1, 0, 0);
+            }
             matrixStack.mulPose(Direction.SOUTH.getRotation());
             matrixStack.scale(1f, 1f, 1f);
         }

--- a/src/main/java/cn/solarmoon/spyglass_of_curios/mixin/RenderItem.java
+++ b/src/main/java/cn/solarmoon/spyglass_of_curios/mixin/RenderItem.java
@@ -25,7 +25,12 @@ public abstract class RenderItem<T extends LivingEntity>{
     public void render(PoseStack poseStack, MultiBufferSource multiBufferSource, int i, T t, float p1, float p2, float p3, float p4, float p5, float p6, CallbackInfo ci) {
         if (t instanceof ISpyUser sp) {
             if (sp.usingSpyglassInCurio()) {
-                this.renderArmWithItem(t, t.getMainHandItem(), ItemDisplayContext.THIRD_PERSON_RIGHT_HAND, HumanoidArm.RIGHT, poseStack, multiBufferSource, i);
+                HumanoidArm arm = t.getMainArm();
+                ItemDisplayContext context = (arm == HumanoidArm.RIGHT)
+                        ? ItemDisplayContext.THIRD_PERSON_RIGHT_HAND
+                        : ItemDisplayContext.THIRD_PERSON_LEFT_HAND;
+
+                this.renderArmWithItem(t, t.getMainHandItem(), context, arm, poseStack, multiBufferSource, i);
                 ci.cancel();
             }
         }


### PR DESCRIPTION
Fixes the spyglass always being positioned on the left eye, even when the player model is left handed.
Also fixes the main hand item always being moved to the right hand, similar to the other issue.